### PR TITLE
fix 'Follow the Crypto' Mastodon link

### DIFF
--- a/src/_data/ftcSocialLinks.js
+++ b/src/_data/ftcSocialLinks.js
@@ -6,7 +6,7 @@ const data = [
   },
   {
     label: "Mastodon",
-    href: "https://hachyderm.io/followthecrypto",
+    href: "https://hachyderm.io/@followthecrypto",
     username: "@followthecrypto@hachyderm.io",
   },
   {


### PR DESCRIPTION
Missing an @ sign